### PR TITLE
Increase ipmi BT to 64 bytes

### DIFF
--- a/ipmid.H
+++ b/ipmid.H
@@ -16,7 +16,7 @@ ipmi_ret_t ipmi_netfn_router(const ipmi_netfn_t, const ipmi_cmd_t, ipmi_request_
 // The BT FIFO in the AST2400 can only handle 64 bytes.  
 // Can only allow 63 because the BT interface still 
 // needs 1 byte for the length field. 
-#define MAX_IPMI_BUFFER 63
+#define MAX_IPMI_BUFFER 64
 
 extern FILE *ipmiio, *ipmidbus, *ipmicmddetails;
 


### PR DESCRIPTION
after a lot of testing and verification from Hostboot it appears it is
fine to move this back to 64 bytes.  I'm doing this to reduce the
number of IPMI calls from the host.