### PR TITLE
Enable debug data section of event logs

### DIFF
--- a/storagehandler.C
+++ b/storagehandler.C
@@ -138,8 +138,6 @@ ipmi_ret_t ipmi_storage_add_sel(ipmi_netfn_t netfn, ipmi_cmd_t cmd,
     // Pack the actual response
     memcpy(response, &p->eventdata[1], 2);
 
-    // TODO This code should grab the completed partial esel located in
-    // the /tmp/esel0100 file and commit it to the error log handler.
     send_esel(recordid);
 
     return rc;


### PR DESCRIPTION
until now event logs have 3 bytes of debug data.  This was due to
a bug in our debug / testing interface.  Now that the problem has
been resolved we can start seeing the full ESEL over the rest
interface.  This will lead to larger files in the writable
filesystem.