### PR TITLE
Fixing the Duplicate registration for NetFn [0x6], Cmd:[0xFF]

### DIFF
--- a/globalhandler.C
+++ b/globalhandler.C
@@ -164,8 +164,5 @@ void register_netfn_global_functions()
     printf("Registering NetFn:[0x%X], Cmd:[0x%X]\n",NETFUN_APP, IPMI_CMD_WARM_RESET);
     ipmi_register_callback(NETFUN_APP, IPMI_CMD_WARM_RESET, NULL, ipmi_global_warm_reset);
 
-    printf("Registering NetFn:[0x%X], Cmd:[0x%X]\n",NETFUN_APP, IPMI_CMD_WILDCARD);
-    ipmi_register_callback(NETFUN_APP, IPMI_CMD_WILDCARD, NULL, ipmi_global_wildcard_handler);
-
-	return;
+    return;
 }

--- a/globalhandler.C
+++ b/globalhandler.C
@@ -142,22 +142,6 @@ ipmi_ret_t ipmi_global_warm_reset(ipmi_netfn_t netfn, ipmi_cmd_t cmd,
     return rc;
 }
 
-ipmi_ret_t ipmi_global_wildcard_handler(ipmi_netfn_t netfn, ipmi_cmd_t cmd,
-                              ipmi_request_t request, ipmi_response_t response,
-                              ipmi_data_len_t data_len, ipmi_context_t context)
-{
-    printf("Handling WILDCARD Netfn:[0x%X], Cmd:[0x%X]\n",netfn, cmd);
-
-    // Status code.
-    ipmi_ret_t rc = IPMI_CC_OK;
-
-    *data_len = strlen("THIS IS WILDCARD");
-
-    // Now pack actual response
-    memcpy(response, "THIS IS WILDCARD", *data_len);
-
-    return rc;
-}
 
 void register_netfn_global_functions()
 {


### PR DESCRIPTION
This NetFn [0x6], Cmd:[0xFF] is getting registered in both apphandler.C and globalhandler.C causing a duplicate registration. 

--> The fix is to remove the registration in globalhandler.C

apphandler.C and globalhandler.C are part of libapphandler library.