### PR TITLE
Modify eSEL to follow IPMI spec:

### DIFF
--- a/ipmid-api.h
+++ b/ipmid-api.h
@@ -58,6 +58,8 @@ typedef ipmi_ret_t (*ipmid_callback_t)(ipmi_netfn_t, ipmi_cmd_t, ipmi_request_t,
 void ipmi_register_callback(ipmi_netfn_t, ipmi_cmd_t,
                                        ipmi_context_t, ipmid_callback_t);
 
+unsigned short get_sel_reserve_id(void);
+
 // These are the command network functions, the response
 // network functions are the function + 1. So to determine
 // the proper network function which issued the command
@@ -91,6 +93,7 @@ enum ipmi_return_codes
     IPMI_CC_OK = 0x00,
     IPMI_DCMI_CC_NO_ACTIVE_POWER_LIMIT = 0x80,
     IPMI_CC_INVALID = 0xC1,
+    IPMI_CC_INVALID_RESERVATION_ID = 0xC5,
     IPMI_CC_PARM_OUT_OF_RANGE = 0xC9,
     IPMI_CC_SENSOR_INVALID = 0xCB,
     IPMI_CC_RESPONSE_ERROR = 0xCE,

--- a/ipmid.C
+++ b/ipmid.C
@@ -26,8 +26,6 @@ void print_usage(void) {
   fprintf(stderr, "    mask : 0xFF - Print all trace\n");
 }
 
-
-
 const char * DBUS_INTF = "org.openbmc.HostIpmi";
 
 const char * FILTER = "type='signal',interface='org.openbmc.HostIpmi',member='ReceivedMessage'";
@@ -39,6 +37,13 @@ typedef std::pair<ipmid_callback_t, ipmi_context_t> ipmi_fn_context_t;
 // Global data structure that contains the IPMI command handler's registrations.
 std::map<ipmi_fn_cmd_t, ipmi_fn_context_t> g_ipmid_router_map;
 
+// IPMI Spec, shared Reservation ID.
+unsigned short g_sel_reserve = 0xFFFF;
+
+unsigned short get_sel_reserve_id(void)
+{
+    return g_sel_reserve;
+}
 
 #ifndef HEXDUMP_COLS
 #define HEXDUMP_COLS 16
@@ -341,8 +346,8 @@ void ipmi_register_callback_handlers(const char* ipmi_lib_path)
         handler_fqdn += "/";
 
         num_handlers = scandir(ipmi_lib_path, &handler_list, handler_select, alphasort);
-	if (num_handlers < 0)
-		return;
+        if (num_handlers < 0)
+            return;
 
         while(num_handlers--)
         {
@@ -351,6 +356,7 @@ void ipmi_register_callback_handlers(const char* ipmi_lib_path)
             printf("Registering handler:[%s]\n",handler_fqdn.c_str());
 
             lib_handler = dlopen(handler_fqdn.c_str(), RTLD_NOW);
+
             if(lib_handler == NULL)
             {
                 fprintf(stderr,"ERROR opening [%s]: %s\n",
@@ -359,6 +365,7 @@ void ipmi_register_callback_handlers(const char* ipmi_lib_path)
             // Wipe the memory allocated for this particular entry.
             free(handler_list[num_handlers]);
         }
+
         // Done with all registration.
         free(handler_list);
     }

--- a/storagehandler.C
+++ b/storagehandler.C
@@ -13,7 +13,7 @@ void register_netfn_storage_functions() __attribute__((constructor));
 
 
 unsigned int   g_sel_time    = 0xFFFFFFFF;
-unsigned short g_sel_reserve = 0x1;
+extern unsigned short g_sel_reserve;
 
 ipmi_ret_t ipmi_storage_wildcard(ipmi_netfn_t netfn, ipmi_cmd_t cmd,
                               ipmi_request_t request, ipmi_response_t response,
@@ -100,17 +100,19 @@ ipmi_ret_t ipmi_storage_get_sel_info(ipmi_netfn_t netfn, ipmi_cmd_t cmd,
     return rc;
 }
 
-
-
 ipmi_ret_t ipmi_storage_reserve_sel(ipmi_netfn_t netfn, ipmi_cmd_t cmd,
                               ipmi_request_t request, ipmi_response_t response,
                               ipmi_data_len_t data_len, ipmi_context_t context)
 {
+    unsigned short res_id;
 
     ipmi_ret_t rc = IPMI_CC_OK;
 
-    printf("IPMI Handling RESERVE-SEL 0x%04x\n", g_sel_reserve);
+    // IPMI spec, Reservation ID, the value simply increases against each execution of reserve_sel command.
+    if( ++g_sel_reserve == 0)
+        g_sel_reserve = 1;
 
+    printf("IPMI Handling RESERVE-SEL 0x%04x\n", g_sel_reserve);
 
     *data_len = sizeof(g_sel_reserve);
 


### PR DESCRIPTION
Handle multiple attempts at ipmi reservation ids

1. Keep Reservation ID follow IPMI Spec.
2. Make Reservation ID increase sequentially.
3. Make Reservation ID available in shared librarys.
Signed-off-by: Nan Li bjlinan@cn.ibm.com

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/phosphor-host-ipmid/82)
<!-- Reviewable:end -->
