### PR TITLE
Returning correct value from handle_ipmid_command in ipmid.C

### DIFF
--- a/ipmid.C
+++ b/ipmid.C
@@ -267,6 +267,10 @@ static int handle_ipmi_command(sd_bus_message *m, void *user_data, sd_bus_error
     if(r != 0)
     {
         fprintf(stderr,"ERROR:[0x%X] handling NetFn:[0x%X], Cmd:[0x%X]\n",r, netfn, cmd);
+
+        if(r == -1) {
+           response[0] = IPMI_CC_UNSPECIFIED_ERROR;
+        }
     }
 
     fprintf(ipmiio, "IPMI Response:\n");


### PR DESCRIPTION
Instead of -1, we return 0xFF(Unspecified error) to the bus.

Signed-off-by: Nan Li <bjlinan@cn.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/phosphor-host-ipmid/88)
<!-- Reviewable:end -->
