### PR TITLE
Update ObjectMapper service/interface/path

### DIFF
--- a/chassishandler.C
+++ b/chassishandler.C
@@ -27,9 +27,9 @@ const char *settings_object_name  =  "/org/openbmc/settings/host0";
 const char *settings_intf_name    =  "org.freedesktop.DBus.Properties";
 const char *host_intf_name        =  "org.openbmc.settings.Host";
 
-const char *objmapper_service_name =  "org.openbmc.objectmapper";
-const char *objmapper_object_name  =  "/org/openbmc/objectmapper/objectmapper";
-const char *objmapper_intf_name    =  "org.openbmc.objectmapper.ObjectMapper";
+const char *objmapper_service_name =  "org.openbmc.ObjectMapper";
+const char *objmapper_object_name  =  "/org/openbmc/ObjectMapper";
+const char *objmapper_intf_name    =  "org.openbmc.ObjectMapper";
 
 int object_mapper_get_connection(char **buf, const char *obj_path)
 {

--- a/globalhandler.C
+++ b/globalhandler.C
@@ -7,9 +7,9 @@
 const char  *control_object_name  =  "/org/openbmc/control/bmc0";
 const char  *control_intf_name    =  "org.openbmc.control.Bmc";
 
-const char  *objectmapper_service_name =  "org.openbmc.objectmapper";
-const char  *objectmapper_object_name  =  "/org/openbmc/objectmapper/objectmapper";
-const char  *objectmapper_intf_name    =  "org.openbmc.objectmapper.ObjectMapper";
+const char  *objectmapper_service_name =  "org.openbmc.ObjectMapper";
+const char  *objectmapper_object_name  =  "/org/openbmc/ObjectMapper";
+const char  *objectmapper_intf_name    =  "org.openbmc.ObjectMapper";
 
 void register_netfn_global_functions() __attribute__((constructor));
 


### PR DESCRIPTION
The well known service name, interface and path for the mapper
all changed.  This patch reacts to that.

Signed-off-by: Brad Bishop <bradleyb@fuzziesquirrel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/phosphor-host-ipmid/93)
<!-- Reviewable:end -->
