### PR TITLE
Using reserved 111b value indicate state of power policy none

### DIFF
--- a/chassishandler.cpp
+++ b/chassishandler.cpp
@@ -931,7 +931,8 @@ using DbusValue = RestorePolicy::Policy;
 const std::map<DbusValue, IpmiValue> dbusToIpmi = {
     {RestorePolicy::Policy::AlwaysOff, 0x00},
     {RestorePolicy::Policy::Restore, 0x01},
-    {RestorePolicy::Policy::AlwaysOn, 0x02}};
+    {RestorePolicy::Policy::AlwaysOn, 0x02},
+    {RestorePolicy::Policy::None, 0x07}};
 
 static constexpr uint8_t noChange = 0x03;
 static constexpr uint8_t allSupport = 0x01 | 0x02 | 0x04;


### PR DESCRIPTION
When user call "ipmitool power status" command, ipmitool shows unspecified error, due to property of PowerRestorePolicy is none

Testd:
   1.Set PowerRestorePolicy is none
       ```
       busctl set-property xyz.openbmc_project.Settings
       /xyz/openbmc_project/control/host0/power_restore_policy
       xyz.openbmc_project.Control.Power.RestorePolicy
       PowerRestorePolicy s "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.None"
       ```
   2.Send ipmi power status command, and response unspecified error